### PR TITLE
Default Accept header supplied by proxy incorrect

### DIFF
--- a/src/main/java/eu/fusepool/p3/proxy/ProxyHandler.java
+++ b/src/main/java/eu/fusepool/p3/proxy/ProxyHandler.java
@@ -274,8 +274,14 @@ public class ProxyHandler extends AbstractHandler {
                         }
                     }
                 };
-                Entity transformationResult = transformer.transform(entity);
-                
+
+                Entity transformationResult;
+                try {
+                    transformationResult = transformer.transform(entity, new MimeType("*/*"));
+                } catch (MimeTypeParseException ex) {
+                    throw new RuntimeException(ex);
+                }
+
                 //final HttpEntity httpEntity = response.getEntity();
                 //final Header contentTypeHeader = httpEntity.getContentType();
                 final String contentType = transformationResult.getType().toString();


### PR DESCRIPTION
If acceptedFormats is not supplied to Transformer.transform(), the Accept header supplied by the proxy via the Transformer Client defaults to 'Accept: text/html, image/gif, image/jpeg, _; q=.2, */_; q=.2'. The Virtuoso transformers return '406 Unacceptable' as a result.
